### PR TITLE
Remove all exports

### DIFF
--- a/src/PkgSearch.jl
+++ b/src/PkgSearch.jl
@@ -25,7 +25,7 @@ const search = SearchState(1, "", Dict{AbstractString, Any}(), Dict{AbstractStri
 """
   lookup(keyword1, keyword2, ...)
 
-Searches for Julia packages matching the provided keywords. Search results limited to $items_per_page per lookup. 
+Searches for Julia packages matching the provided keywords. Search results limited to $items_per_page per lookup.
 Returns the results and displays the info in the REPL.
 
 #Examples
@@ -50,17 +50,17 @@ end
     search.page = 1
   end
 
-  try 
-    page_uri = search_api_uri * search_endpoint * "?q=" * replace(keywords, " ", "+") * "&page[number]=$(search.page)&page[size]=$items_per_page" 
+  try
+    page_uri = search_api_uri * search_endpoint * "?q=" * replace(keywords, " ", "+") * "&page[number]=$(search.page)&page[size]=$items_per_page"
     DEBUG && Lumberjack.info(page_uri)
-    search.results = Requests.get(page_uri) |> Requests.json  
-  catch ex 
-    rethrow(ex) # do something better with the exception 
+    search.results = Requests.get(page_uri) |> Requests.json
+  catch ex
+    rethrow(ex) # do something better with the exception
   end
 
   if ! isempty(search.results["data"])
     return process_results(search.results, autorender = autorender)
-  else 
+  else
     return []
   end
 end
@@ -68,7 +68,7 @@ end
 """
   next([page_jump])
 
-Performs a new lookup to bring the next batch of $items_per_page results, if available. If page_jump is provided, it will go directly to that page. 
+Performs a new lookup to bring the next batch of $items_per_page results, if available. If page_jump is provided, it will go directly to that page.
 """
 function next(page_jump::Int = 1)
   search.page += page_jump
@@ -78,7 +78,7 @@ end
 """
   prev([page_jump])
 
-Performs a new lookup to bring the previous batch of $items_per_page results, if available. If page_jump is provided, it will go directly to that page. 
+Performs a new lookup to bring the previous batch of $items_per_page results, if available. If page_jump is provided, it will go directly to that page.
 """
 function prev(page_jump::Int = 1)
   next(page_jump * -1)
@@ -95,7 +95,7 @@ end
     _lookup(package_name, autorender = false)
   end
 
-  package_details = Requests.get(search_api_uri * details_endpoint * "/" * string(search.packages[package_name]["id"])) |> Requests.json 
+  package_details = Requests.get(search_api_uri * details_endpoint * "/" * string(search.packages[package_name]["id"])) |> Requests.json
 
   if isempty(package_details) error("Package not found") end
   autorender && render_package(package_details["data"]["attributes"])
@@ -104,19 +104,19 @@ end
 end
 
 """
-Installs the requested package using the appropriate technique: Pkg.add if it's an official METADATA package, or Pkg.clone if not. 
+Installs the requested package using the appropriate technique: Pkg.add if it's an official METADATA package, or Pkg.clone if not.
 """
 function install(package_name::AbstractString)
   if is_official_package(package_name)
     Pkg.add(package_name)
-  else 
+  else
     pkg_details = details(package_name, autorender = false)
     Pkg.clone(pkg_details["url"])
   end
 end
 
 """
-Returns true if the requested package is official, that is part of METADATA. False otherwise. 
+Returns true if the requested package is official, that is part of METADATA. False otherwise.
 """
 function is_official_package(package_name::AbstractString)
   haskey(metadata_packages(), package_name)
@@ -148,7 +148,7 @@ end
 
 function process_results(search_results::Dict; autorender::Bool = false)
   for p in search_results["data"]
-    p["search"]["headline"] = replace(p["search"]["headline"], r"(<b>|</b>)", "**") 
+    p["search"]["headline"] = replace(p["search"]["headline"], r"(<b>|</b>)", "**")
     search.packages[p["attributes"]["name"]] = p
     autorender && render(p)
   end
@@ -182,7 +182,7 @@ function render_package{T<:AbstractString, U<:Any}(p::Dict{T,U})
   println("-----------------------------------------------------")
   display(replace(p["readme"], r"(<b>|</b>)", "**") |> Markdown.parse)
   println("_____________________________________________________\n\n")
-end 
+end
 
 println("Preloading METADATA packages... please wait...")
 metadata_packages()

--- a/src/PkgSearch.jl
+++ b/src/PkgSearch.jl
@@ -1,7 +1,5 @@
 module PkgSearch
 
-export lookup, details, next, prev, packages
-
 const DEBUG = false
 
 using Requests


### PR DESCRIPTION
On julia-0.5 one was getting the following warning:

```
WARNING: using PkgSearch.next in module Main conflicts with an existing identifier.
```

That's because PkgSearch doesn't `import Base: next`. But I don't really see any reason to extend `next`, you just want your own private version of `next`, so the obvious thing to do is to not export it. Since in your README all your functions are scoped by the module, it seems reasonable to just delete all exports.

The first commit contains the only "real" change, the rest is just whitespace (I have emacs set to delete trailing whitespace, etc).
